### PR TITLE
Fix lambda function name reference to `RequestUnicorn`

### DIFF
--- a/WebApplication/3_ServerlessBackend/README.md
+++ b/WebApplication/3_ServerlessBackend/README.md
@@ -102,7 +102,7 @@ Make sure to configure your function to use the `WildRydesLambda` IAM role you c
 
 1. Don't add any triggers at this time. Choose **Next** to proceed to defining your function.
 
-1. Enter `RequestRide` in the **Name** field.
+1. Enter `RequestUnicorn` in the **Name** field.
 
 1. Optionally enter a description.
 

--- a/WebApplication/4_RESTfulAPIs/README.md
+++ b/WebApplication/4_RESTfulAPIs/README.md
@@ -97,7 +97,7 @@ Create a new resource called /ride within your API. Then create a POST method fo
 
 1. Select the Region you are using for **Lambda Region**.
 
-1. Enter the name of the function you created in the previous module, `RequestRide`, for **Lambda Function**.
+1. Enter the name of the function you created in the previous module, `RequestUnicorn`, for **Lambda Function**.
 
 1. Choose **Save**.
 


### PR DESCRIPTION
The Lambda function created in the previous module (module 3) is named `RequestUnicorn` not `RequestRide`. This PR fixes that.