### PR TITLE
Fixing typo in website url in a README

### DIFF
--- a/WebApplication/1_StaticWebHosting/README.md
+++ b/WebApplication/1_StaticWebHosting/README.md
@@ -51,7 +51,7 @@ The architecture for this module is very straightforward. All of your static web
 
 ![Static website architecture](../images/static-website-architecture.png)
 
-For the purposes of this module you'll use the Amazon S3 website endpoint URL that we supply. It takes the form `http://{your-bucket-name}.s3-website.{region}.amazonaws.com`. For most real applications you'll want to use a custom domain to host your site. If you're interested in using a your own domain, follow the instructions for [setting up a static website using a custom domain](http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html) in the Amazon S3 documentation.
+For the purposes of this module you'll use the Amazon S3 website endpoint URL that we supply. It takes the form `http://{your-bucket-name}.s3-website-{region}.amazonaws.com`. For most real applications you'll want to use a custom domain to host your site. If you're interested in using a your own domain, follow the instructions for [setting up a static website using a custom domain](http://docs.aws.amazon.com/AmazonS3/latest/dev/website-hosting-custom-domain-walkthrough.html) in the Amazon S3 documentation.
 
 ## Implementation Instructions
 


### PR DESCRIPTION
Templated WildRydes URL in one of the README's has a small typo.