### PR TITLE
User management CloudFormation template update

### DIFF
--- a/WebApplication/2_UserManagement/user-management.yaml
+++ b/WebApplication/2_UserManagement/user-management.yaml
@@ -32,7 +32,7 @@ Resources:
   UserPoolClient:
     Properties:
       ServiceToken: !GetAtt CreateUserPoolClientFunction.Arn
-      Name: WildRydesWeb
+      Name: WildRydesWebApp
       UserPool: !Ref UserPool
     Type: "Custom::UserPoolClient"
 
@@ -172,8 +172,18 @@ Resources:
           def create(properties, physical_id):
             result = cognito.create_user_pool(
               PoolName=properties['Name'],
-              AutoVerifiedAttributes=[],
-              AliasAttributes=['email']
+              VerificationMessageTemplate={
+                  'DefaultEmailOption': 'CONFIRM_WITH_CODE'
+              },
+              AutoVerifiedAttributes=['email'],
+              Schema=[
+                  {
+                      'Name': 'email',
+                      'AttributeDataType': 'String',
+                      'Required': True
+                      
+                  }
+              ]
             )
             return cfnresponse.SUCCESS, result['UserPool']['Id']
 


### PR DESCRIPTION
Updated the CreateUserPoolFunction so it creates the same "default" console configuration for the Cognito User Pool. The template was not setting the "Do you want to require verification of emails or phone numbers?" in the verification settings. Also updated the client application name to match the instructions in the readme.md file.