### PR TITLE
Fix for relative deployed paths

### DIFF
--- a/WebApplication/1_StaticWebHosting/website/apply.html
+++ b/WebApplication/1_StaticWebHosting/website/apply.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Apply - Wild Rydes</title>
 
-  <link rel="stylesheet" href="css/font.css">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="stylesheet" href="./css/font.css">
+  <link rel="stylesheet" href="./css/main.css">
 
   <script src="js/vendor/modernizr.js"></script>
 </head>

--- a/WebApplication/1_StaticWebHosting/website/faq.html
+++ b/WebApplication/1_StaticWebHosting/website/faq.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>FAQ - Wild Rydes</title>
 
-  <link rel="stylesheet" href="css/font.css">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="stylesheet" href="./css/font.css">
+  <link rel="stylesheet" href="./css/main.css">
 
   <script src="js/vendor/modernizr.js"></script>
 </head>

--- a/WebApplication/1_StaticWebHosting/website/index.html
+++ b/WebApplication/1_StaticWebHosting/website/index.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Wild Rydes</title>
 
-  <link rel="stylesheet" href="css/font.css">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="stylesheet" href="./css/font.css">
+  <link rel="stylesheet" href="./css/main.css">
 
   <script src="js/vendor/modernizr.js"></script>
 </head>

--- a/WebApplication/1_StaticWebHosting/website/investors.html
+++ b/WebApplication/1_StaticWebHosting/website/investors.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Investors &amp; Board of Directors - Wild Rydes</title>
 
-  <link rel="stylesheet" href="css/font.css">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="stylesheet" href="./css/font.css">
+  <link rel="stylesheet" href="./css/main.css">
 
   <script src="js/vendor/modernizr.js"></script>
 </head>

--- a/WebApplication/1_StaticWebHosting/website/js/ride.js
+++ b/WebApplication/1_StaticWebHosting/website/js/ride.js
@@ -9,11 +9,11 @@ WildRydes.map = WildRydes.map || {};
         if (token) {
             authToken = token;
         } else {
-            window.location.href = '/signin.html';
+            window.location.href = './signin.html';
         }
     }).catch(function handleTokenError(error) {
         alert(error);
-        window.location.href = '/signin.html';
+        window.location.href = './signin.html';
     });
     function requestUnicorn(pickupLocation) {
         $.ajax({

--- a/WebApplication/1_StaticWebHosting/website/register.html
+++ b/WebApplication/1_StaticWebHosting/website/register.html
@@ -10,12 +10,12 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
 
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-
-        <link rel="stylesheet" href="css/font.css">
-        <link rel="stylesheet" href="css/normalize.css">
-        <link rel="stylesheet" href="css/index.css">
-        <link rel="stylesheet" href="/css/message.css">
+        <!-- Place apple-touch-icon.png in the root directory -->
+        <link rel="shortcut icon" href="./favicon.ico">
+        <link rel="stylesheet" href="./css/font.css">
+        <link rel="stylesheet" href="./css/normalize.css">
+        <link rel="stylesheet" href="./css/index.css">
+        <link rel="stylesheet" href="./css/message.css">
     </head>
     <body>
         <!--[if lt IE 7]>

--- a/WebApplication/1_StaticWebHosting/website/ride.html
+++ b/WebApplication/1_StaticWebHosting/website/ride.html
@@ -12,10 +12,11 @@
     <meta name="author" content="">
 
 
+    <link rel="shortcut icon" href="./favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://js.arcgis.com/4.3/esri/css/main.css">
-    <link rel="stylesheet" href="/css/ride.css">
-    <link rel="stylesheet" href="/css/message.css">
+    <link rel="stylesheet" href="./css/ride.css">
+    <link rel="stylesheet" href="./css/message.css">
 </head>
 
 <body>

--- a/WebApplication/1_StaticWebHosting/website/signin.html
+++ b/WebApplication/1_StaticWebHosting/website/signin.html
@@ -10,12 +10,12 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
 
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-
-        <link rel="stylesheet" href="css/font.css">
-        <link rel="stylesheet" href="css/normalize.css">
-        <link rel="stylesheet" href="css/index.css">
-        <link rel="stylesheet" href="/css/message.css">
+        <!-- Place apple-touch-icon.png in the root directory -->
+        <link rel="shortcut icon" href="./favicon.ico">
+        <link rel="stylesheet" href="./css/font.css">
+        <link rel="stylesheet" href="./css/normalize.css">
+        <link rel="stylesheet" href="./css/index.css">
+        <link rel="stylesheet" href="./css/message.css">
     </head>
     <body>
         <!--[if lt IE 7]>

--- a/WebApplication/1_StaticWebHosting/website/unicorns.html
+++ b/WebApplication/1_StaticWebHosting/website/unicorns.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Unicorns - Wild Rydes</title>
 
-  <link rel="stylesheet" href="css/font.css">
-  <link rel="stylesheet" href="css/main.css">
+  <link rel="shortcut icon" href="./favicon.ico">
+  <link rel="stylesheet" href="./css/font.css">
+  <link rel="stylesheet" href="./css/main.css">
 
   <script src="js/vendor/modernizr.js"></script>
 </head>

--- a/WebApplication/1_StaticWebHosting/website/verify.html
+++ b/WebApplication/1_StaticWebHosting/website/verify.html
@@ -10,12 +10,12 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
 
-        <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-
-        <link rel="stylesheet" href="css/font.css">
-        <link rel="stylesheet" href="css/normalize.css">
-        <link rel="stylesheet" href="css/index.css">
-        <link rel="stylesheet" href="/css/message.css">
+        <!-- Place apple-touch-icon.png in the root directory -->
+        <link rel="shortcut icon" href="./favicon.ico">
+        <link rel="stylesheet" href="./css/font.css">
+        <link rel="stylesheet" href="./css/normalize.css">
+        <link rel="stylesheet" href="./css/index.css">
+        <link rel="stylesheet" href="./css/message.css">
     </head>
     <body>
         <!--[if lt IE 7]>

--- a/WebApplication/5_OAuth/UnicornManager/index.html
+++ b/WebApplication/5_OAuth/UnicornManager/index.html
@@ -13,8 +13,8 @@
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://js.arcgis.com/4.3/esri/css/main.css">
-    <link rel="stylesheet" href="/css/ride.css">
-    <link rel="stylesheet" href="/css/message.css">
+    <link rel="stylesheet" href="./css/ride.css">
+    <link rel="stylesheet" href="./css/message.css">
 </head>
 
 <body style="background: url(images/background.png) no-repeat;">


### PR DESCRIPTION
When I created my S3 bucket, and then viewed it, it was at https://s3.amazonaws.com/wildrydes-firstname-lastname/ride.html, this resulted in a lot of the links not working because all the CSS files were assumed to be off the root, so it was looking in https://s3.amazonaws.com/css/* and couldn't find them.

I've updated all the paths to be relative (./css/...) as well as adding links to the shortcut icon to its relative path (i.e. ./favicon.ico) since that was also giving me errors