### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/ImageProcessing/src/cloudformation/module-setup.yaml
+++ b/ImageProcessing/src/cloudformation/module-setup.yaml
@@ -76,7 +76,7 @@ Resources:
     Properties:
       Description: "Use Amazon Rekognition to detect faces"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -101,7 +101,7 @@ Resources:
     Properties:
       Description: "mock notification sender"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 256
       Timeout: 60
       CodeUri:
@@ -112,7 +112,7 @@ Resources:
     Properties:
       Description: "Use Amazon Rekognition to check if the face is already in the collection"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -139,7 +139,7 @@ Resources:
     Properties:
       Description: "Index the photo into Rekognition collection"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 256
       Timeout: 60
       Policies:
@@ -167,7 +167,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 1536
       Timeout: 300
       Policies:
@@ -195,7 +195,7 @@ Resources:
     Properties:
       Description: "Save metadata of the photo to DynamoDB table"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       MemorySize: 256
       Timeout: 60
       Environment:

--- a/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-failover-region.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -126,7 +126,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy

--- a/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
+++ b/MultiRegion/1_API/wild-rydes-api-primary-region.yaml
@@ -100,7 +100,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-get.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: TicketGetFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -126,7 +126,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: tickets-post.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: TicketPostFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy
@@ -151,7 +151,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: health-check.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       FunctionName: SXRHealthCheckFunction
       Policies:
         - AWSLambdaDynamoDBExecutionRole #managed policy


### PR DESCRIPTION
CloudFormation templates in aws-serverless-workshops have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.